### PR TITLE
DESKTOP-529: Fix Linux empty impl + release 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zelloptt/desktop-proxy-settings",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zelloptt/desktop-proxy-settings",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zelloptt/desktop-proxy-settings",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "This package reads system proxy settings on Windows and Mac",
   "main": "index.js",
   "gypfile": true,

--- a/src/ProxySettingsEmptyImpl.cpp
+++ b/src/ProxySettingsEmptyImpl.cpp
@@ -3,7 +3,9 @@
 Napi::Object ProxySettings::read(const Napi::CallbackInfo& info)
 {
 	Napi::Env env = info.Env();
-	return Napi::Object::New(env);
+	Napi::Object object = Napi::Object::New(env);
+	object.Set("enabled", Napi::Boolean::New(env, false));
+	return object;
 }
 
 Napi::String ProxySettings::dump(const Napi::CallbackInfo& info)

--- a/src/ProxySettingsEmptyImpl.cpp
+++ b/src/ProxySettingsEmptyImpl.cpp
@@ -1,34 +1,26 @@
 #include "ProxySettings.h"
 
-Napi::Boolean ProxySettings::enabled(const Napi::CallbackInfo& info)
+Napi::Object ProxySettings::read(const Napi::CallbackInfo& info)
 {
-    Napi::Env env = info.Env();
-	return Napi::Boolean::New(env, false);
+	Napi::Env env = info.Env();
+	return Napi::Object::New(env);
 }
 
-Napi::Object ProxySettings::reload(const Napi::CallbackInfo& info)
+Napi::String ProxySettings::dump(const Napi::CallbackInfo& info)
 {
-    Napi::Env env = info.Env();
-    Object obj = Object::New(env);
-    return obj;
-}
-
-Napi::String dump(const Napi::CallbackInfo& info);
-{
-    Napi::Env env = info.Env();
+	Napi::Env env = info.Env();
 	return Napi::String::New(env, "");
 }
 
 Napi::Boolean ProxySettings::openSystemSettings(const Napi::CallbackInfo& info)
 {
-    Napi::Env env = info.Env();
-    return Napi::Boolean::New(env, false);
+	Napi::Env env = info.Env();
+	return Napi::Boolean::New(env, false);
 }
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports)
 {
-	exports.Set("enabled", Napi::Function::New(env, ProxySettings::enabled));
-	exports.Set("reload", Napi::Function::New(env, ProxySettings::reload));
+	exports.Set("read", Napi::Function::New(env, ProxySettings::read));
 	exports.Set("dump", Napi::Function::New(env, ProxySettings::dump));
 	exports.Set("openSystemSettings", Napi::Function::New(env, ProxySettings::openSystemSettings));
 	return exports;


### PR DESCRIPTION
## Summary

\`@zelloptt/desktop-proxy-settings@1.1.1\` cannot be installed from source on Linux. \`src/ProxySettingsEmptyImpl.cpp\` doesn't match the header (\`ProxySettings.h\` declares \`read\` / \`dump\` / \`openSystemSettings\`, the stub defines \`enabled\` / \`reload\` / \`openSystemSettings\` and an unqualified free-function \`dump\`), and the linux-x64 napi-v8 prebuilt isn't published on S3 (returns 403). So node-pre-gyp falls back to source compile and \`npm install\` fails on every Linux runner.

This blocks the new \`zello-desktop\` smoke gate (which runs on \`ubuntu-latest\`) until the published version is fixed.

## Bugs fixed

\`ProxySettingsEmptyImpl.cpp\`:

1. \`enabled\` and \`reload\` were defined as \`ProxySettings\` members but neither is declared in \`ProxySettings.h\` and neither is exposed by the JS wrapper in \`index.js\` (which calls \`impl.read\` and \`impl.dump\`). They were dead names.
2. \`dump\` was declared \`Napi::String dump(const Napi::CallbackInfo& info);\` — missing the \`ProxySettings::\` qualifier and a stray \`;\` between the parameter list and the body, so the next \`{\` token landed at global scope and bailed compilation.
3. \`Object obj = Object::New(env);\` was missing the \`Napi::\` qualifier.
4. \`InitAll\` exported \`enabled\` and \`reload\` (which don't exist) on top of \`dump\` and \`openSystemSettings\`.

Replace the file with a clean stub that matches the header and the JS API: \`read\` returns an empty \`Napi::Object\`, \`dump\` returns an empty \`Napi::String\`, \`openSystemSettings\` returns \`false\`. \`InitAll\` exports those three.

## Why bump to 1.1.2

So the consumer side (\`zello-desktop/package.json\`) can pin to \`^1.1.2\` and drop the workflow-level sed patch we ship as a stopgap.

## Test plan

- [ ] Existing macOS / Windows builds still pass (the file is Linux-only; those branches in \`binding.gyp\` aren't touched).
- [ ] \`npm install\` on linux-x64 succeeds against the source compile path.
- [ ] After merge + npm publish: bump \`zello-desktop\` to \`^1.1.2\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)